### PR TITLE
修复DefaultFastFileStorageClient不兼容空扩展名的问题

### DIFF
--- a/src/main/java/com/github/tobato/fastdfs/service/DefaultFastFileStorageClient.java
+++ b/src/main/java/com/github/tobato/fastdfs/service/DefaultFastFileStorageClient.java
@@ -105,7 +105,6 @@ public class DefaultFastFileStorageClient extends DefaultGenerateStorageClient i
     @Override
     public StorePath uploadFile(FastFile fastFile) {
         Validate.notNull(fastFile.getInputStream(), "上传文件流不能为空");
-        Validate.notBlank(fastFile.getFileExtName(), "文件扩展名不能为空");
         // 获取存储节点
         StorageNode client = getStorageNode(fastFile.getGroupName());
         // 上传文件

--- a/src/test/java/com/github/tobato/fastdfs/service/FastFileStorageClientTest.java
+++ b/src/test/java/com/github/tobato/fastdfs/service/FastFileStorageClientTest.java
@@ -9,6 +9,7 @@ import com.github.tobato.fastdfs.domain.fdfs.MetaData;
 import com.github.tobato.fastdfs.domain.fdfs.StorePath;
 import com.github.tobato.fastdfs.domain.fdfs.ThumbImageConfig;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.logging.log4j.util.Strings;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -23,9 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * FastFileStorageClient客户端
@@ -87,6 +90,33 @@ public class FastFileStorageClientTest {
 
         LOGGER.debug("##删除文件..##");
         storageClient.deleteFile(path.getFullPath());
+    }
+
+    /**
+     * 测试上传文件的时候不提供后缀名称
+     */
+    @Test
+    public void testUploadWithoutExtName() {
+        // null扩展名的文件
+        LOGGER.debug("##上传具有null扩展名的文件..##");
+        RandomTextFile file = new RandomTextFile();
+        file.setFileExtName(null);
+        assertNull(file.getFileExtName());
+
+        StorePath path = storageClient.uploadFile(file.getInputStream(),
+                file.getFileSize(), file.getFileExtName(), Collections.<MetaData>emptySet());
+        assertNotNull(path);
+        LOGGER.debug("上传文件 result={}", path);
+        // 空字串扩展名文件
+        LOGGER.debug("##上传具有空字符串扩展名的文件..##");
+        file = new RandomTextFile();
+        file.setFileExtName(Strings.EMPTY);
+        assertEquals(Strings.EMPTY, file.getFileExtName());
+
+        path = storageClient.uploadFile(file.getInputStream(),
+                file.getFileSize(), file.getFileExtName(), Collections.<MetaData>emptySet());
+        assertNotNull(path);
+        LOGGER.debug("上传文件 result={}", path);
     }
 
     /**


### PR DESCRIPTION
您好,针对问题#117,您的回答中采用的DefaultAppendFileStorageClient(或者说是DefaultGenerateStorageClient)不存在空扩展名的兼容问题,但是更为简单且常用的DefaultFastFileStorageClient中却仍然存在过度检查空扩展名的问题,导致无法使用FastFileStorageClient接口上传带有空扩展名的文件.
这里我删掉了那个参数检查,针对这一问题我在FastFileStorageClientTest中增加了相应测试,在我本地此测试可以通过并输出正确的FastDFS文件索引:
```
2020-06-30 11:36:38,815 [main] INFO  com.github.tobato.fastdfs.service.FastFileStorageClientTest - Started FastFileStorageClientTest in 5.079 seconds (JVM running for 7.594)
2020-06-30 11:36:38,867 [main] DEBUG com.github.tobato.fastdfs.service.FastFileStorageClientTest - ##上传具有null扩展名的文件..##
2020-06-30 11:36:38,880 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 获取到Tracker连接地址localhost/127.0.0.1:22122
2020-06-30 11:36:38,888 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - connect to localhost/127.0.0.1:22122 soTimeout=1501 connectTimeout=1601
2020-06-30 11:36:38,906 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - check connection status of com.github.tobato.fastdfs.domain.conn.DefaultConnection@57adfab0 
2020-06-30 11:36:38,911 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 对地址localhost/127.0.0.1:22122发出交易请求TrackerGetStoreStorageCommand
2020-06-30 11:36:38,952 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - return connect com.github.tobato.fastdfs.domain.conn.DefaultConnection@57adfab0
2020-06-30 11:36:38,965 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - connect to /169.254.43.205:23000 soTimeout=1501 connectTimeout=1601
2020-06-30 11:36:38,975 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - check connection status of com.github.tobato.fastdfs.domain.conn.DefaultConnection@476a736d 
2020-06-30 11:36:38,983 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 对地址/169.254.43.205:23000发出交易请求StorageUploadFileCommand
2020-06-30 11:36:39,016 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - return connect com.github.tobato.fastdfs.domain.conn.DefaultConnection@476a736d
2020-06-30 11:36:39,016 [main] DEBUG com.github.tobato.fastdfs.service.FastFileStorageClientTest - 上传文件 result=StorePath [group=group1, path=M00/00/06/qf4rzV76s0eAM76WAAAAHmDODTU6808577]
2020-06-30 11:36:39,016 [main] DEBUG com.github.tobato.fastdfs.service.FastFileStorageClientTest - ##上传具有空字符串扩展名的文件..##
2020-06-30 11:36:39,016 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 获取到Tracker连接地址localhost/127.0.0.1:22122
2020-06-30 11:36:39,017 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - check connection status of com.github.tobato.fastdfs.domain.conn.DefaultConnection@57adfab0 
2020-06-30 11:36:39,017 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 对地址localhost/127.0.0.1:22122发出交易请求TrackerGetStoreStorageCommand
2020-06-30 11:36:39,017 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - return connect com.github.tobato.fastdfs.domain.conn.DefaultConnection@57adfab0
2020-06-30 11:36:39,018 [main] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - check connection status of com.github.tobato.fastdfs.domain.conn.DefaultConnection@476a736d 
2020-06-30 11:36:39,018 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - 对地址/169.254.43.205:23000发出交易请求StorageUploadFileCommand
2020-06-30 11:36:39,031 [main] DEBUG com.github.tobato.fastdfs.domain.conn.FdfsConnectionManager - return connect com.github.tobato.fastdfs.domain.conn.DefaultConnection@476a736d
2020-06-30 11:36:39,031 [main] DEBUG com.github.tobato.fastdfs.service.FastFileStorageClientTest - 上传文件 result=StorePath [group=group1, path=M00/00/06/qf4rzV76s0eAPvx2AAAAHqpkC1U9838063]
2020-06-30 11:36:39,055 [Thread-2] WARN  org.springframework.jmx.export.annotation.AnnotationMBeanExporter - Could not unregister MBean [com.github.tobato.fastdfs.domain.conn:name=fdfsConnectionPool,type=FdfsConnectionPool] as said MBean is not registered (perhaps already unregistered by an external process)
2020-06-30 11:36:39,056 [Thread-2] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - disconnect from Socket[addr=localhost/127.0.0.1,port=22122,localport=16562]
2020-06-30 11:36:39,061 [Thread-2] DEBUG com.github.tobato.fastdfs.domain.conn.DefaultConnection - disconnect from Socket[addr=/169.254.43.205,port=23000,localport=16564]
```
最后,感谢您在百忙中抽空Review我的代码.