### PR TITLE
支持配置文件指定连接中断后重试时间间隔（原来的程序写死10分钟且不可修改）

### DIFF
--- a/src/main/java/com/github/tobato/fastdfs/domain/conn/TrackerConnectionManager.java
+++ b/src/main/java/com/github/tobato/fastdfs/domain/conn/TrackerConnectionManager.java
@@ -34,6 +34,11 @@ public class TrackerConnectionManager extends FdfsConnectionManager {
     private List<String> trackerList = new ArrayList<String>();
 
     /**
+     * 连接中断以后经过N秒重试，不配置时默认为10分钟
+     */
+    private int retryAfterSecond;
+
+    /**
      * 构造函数
      */
     public TrackerConnectionManager() {
@@ -54,6 +59,11 @@ public class TrackerConnectionManager extends FdfsConnectionManager {
     public void initTracker() {
         LOGGER.debug("init trackerLocator {}", trackerList);
         trackerLocator = new TrackerLocator(trackerList);
+        if (0 != retryAfterSecond) {
+            // 如果 retryAfterSecond ！= 0则，表示开发者自己配置了；set相关对象的属性值
+            trackerLocator.setRetryAfterSecond(retryAfterSecond);
+            LOGGER.debug("update trackerLocator retryAfterSecond to [{}]s", retryAfterSecond);
+        }
     }
 
     /**
@@ -88,5 +98,13 @@ public class TrackerConnectionManager extends FdfsConnectionManager {
 
     public void setTrackerList(List<String> trackerList) {
         this.trackerList = trackerList;
+    }
+
+    public int getRetryAfterSecond() {
+        return retryAfterSecond;
+    }
+
+    public void setRetryAfterSecond(int retryAfterSecond) {
+        this.retryAfterSecond = retryAfterSecond;
     }
 }


### PR DESCRIPTION
### 场景：
fastdfs挂了被重启后，程序没有重新建立连接，导致需要运维重启应用程序；经过分析发现是这个连接中断后的重试间隔太长了，10分钟太久了。因此希望将该参数放出来变成一个可配置项（程序里面写死了10分钟），故提交了此次pr

### 使用说明：
如果不配置，连接中断后重试时间间隔还是10分钟；如果需要修改，可以参考如下配置:
```yml
fdfs:
  #配置连接中断后，30s重连
  retry-after-second: 30
```
