### PR TITLE
Fix the bug of getting port 0

### DIFF
--- a/src/main/java/com/github/tobato/fastdfs/domain/proto/OtherConstants.java
+++ b/src/main/java/com/github/tobato/fastdfs/domain/proto/OtherConstants.java
@@ -20,7 +20,7 @@ public final class OtherConstants {
     public static final int FDFS_PROTO_CMD_SIZE = 1;
     public static final int FDFS_PROTO_CONNECTION_LEN = 4;
     public static final int FDFS_GROUP_NAME_MAX_LEN = 16;
-    public static final int FDFS_IPADDR_SIZE = 16;
+    public static final int FDFS_IPADDR_SIZE = 46; // Original size is 16, which caused the problem of getting a wrong port "0".
     public static final int FDFS_DOMAIN_NAME_MAX_SIZE = 128;
     public static final int FDFS_VERSION_SIZE = 6;
     public static final int FDFS_STORAGE_ID_MAX_SIZE = 16;


### PR DESCRIPTION
FastDFS：[V6.12.1](https://github.com/happyfish100/fastdfs/releases/tag/V6.12.1)
解决获取Storage节点的port为0的问题